### PR TITLE
style: pointer cursor on title graphic; soften card glow and instant fade-out

### DIFF
--- a/src/components/curriculumGrid/curriculumCard/styles.module.scss
+++ b/src/components/curriculumGrid/curriculumCard/styles.module.scss
@@ -15,7 +15,8 @@ a.card {
   border: var(--theme-border);
   border-width: 1px;
   border-style: solid;
-  transition: all 0.3s ease;
+  // make hover-in animated but hover-out immediate by placing transitions on :hover only
+  transition: none;
   z-index: 2;
   cursor: pointer;
   overflow: hidden;
@@ -27,24 +28,26 @@ a.card {
   }
 
   &:hover {
+    // subtle glow: smaller blur and lower alpha; animate only on hover-in
+    transition: box-shadow 200ms ease, border-color 200ms ease;
     z-index: 3;
     &.blue, & { // default is blue
-      box-shadow: 0px 0px 64px 2px color.change(c.color(blue-darklink), $alpha: 50%);
+      box-shadow: 0px 0px 32px 1px color.change(c.color(blue-darklink), $alpha: 25%);
       border-color: color.change(color.adjust(c.color(blue-darklink), $lightness: 10%), $alpha: 50%);
     }
     
     &.green {
-      box-shadow: 0px 0px 64px 2px color.change(c.color(green-darklink), $alpha: 50%);
+      box-shadow: 0px 0px 32px 1px color.change(c.color(green-darklink), $alpha: 25%);
       border-color: color.change(color.adjust(c.color(green-darklink), $lightness: 10%), $alpha: 50%);
     }
     
     &.pink {
-      box-shadow: 0px 0px 64px 2px color.change(c.color(pink-darklink), $alpha: 50%);
+      box-shadow: 0px 0px 32px 1px color.change(c.color(pink-darklink), $alpha: 25%);
       border-color: color.change(color.adjust(c.color(pink-darklink), $lightness: 10%), $alpha: 50%);
     }
     
     &.red {
-      box-shadow: 0px 0px 64px 2px color.change(c.color(red-darklink), $alpha: 50%);
+      box-shadow: 0px 0px 32px 1px color.change(c.color(red-darklink), $alpha: 25%);
       border-color: color.change(color.adjust(c.color(red-darklink), $lightness: 10%), $alpha: 50%);
     }
   }

--- a/src/components/layout/navigator/styles.module.scss
+++ b/src/components/layout/navigator/styles.module.scss
@@ -16,6 +16,7 @@
         width: calc(835px / 2);
         height: calc(140px / 2);
         transition: all 250ms ease;
+        cursor: pointer; // indicate clickable title graphic
 
         img {
             object-fit: contain;


### PR DESCRIPTION
Aesthetic tweaks:\n\n- Add pointer cursor on the title graphic/logo in the navbar.\n- Reduce card hover glow (smaller blur radius, lower alpha).\n- Make glow fade-in over 200ms but disappear immediately on hover-out (transitions only on :hover).\n\nBuilt locally on Node 22; no functional changes.